### PR TITLE
Added Guzzle to Project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "fruitcake/laravel-cors": "^2.0",
-        "guzzlehttp/guzzle": "^7.0.1",
+        "guzzlehttp/guzzle": "^7.4",
         "laravel/framework": "^8.65",
         "laravel/sanctum": "^2.11",
         "laravel/tinker": "^2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4842c22e789d247c4b660e69490545f",
+    "content-hash": "73c2f2acec19658d2e63d23620e481f3",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Guzzle is needed for HTTP client to work. This is needed for the core module to save snapshots